### PR TITLE
Optimize components lookup

### DIFF
--- a/apex-demo/src/main/java/dev/romainguy/apex/MainActivity.kt
+++ b/apex-demo/src/main/java/dev/romainguy/apex/MainActivity.kt
@@ -67,7 +67,7 @@ class MainActivity : Activity() {
                         previous.component<ButtonModel>().state =
                             if (imageIndex > 0) State.Enabled else State.Disabled
                         image.component<ImageModel>().bitmap = TestImage[imageIndex]
-                    }).addComponent(Id.ButtonPrevious)
+                    }).addComponent<Id>(Id.ButtonPrevious)
 
                     Button(ButtonModel("Next") { next ->
                         if (imageIndex < TestImage.size - 1) imageIndex++
@@ -76,7 +76,7 @@ class MainActivity : Activity() {
                         requireChild(Id.ButtonPrevious).component<ButtonModel>().state =
                             if (imageIndex > 0) State.Enabled else State.Disabled
                         image.component<ImageModel>().bitmap = TestImage[imageIndex]
-                    }).addComponent(Id.ButtonNext)
+                    }).addComponent<Id>(Id.ButtonNext)
                 }
             }
         }
@@ -93,7 +93,7 @@ class MainActivity : Activity() {
 class ImageModel(var bitmap: Bitmap)
 
 fun Element.Image(model: ImageModel) = ChildElement {
-    addComponent(model)
+    addComponent<ImageModel>(model)
 
     val paint = Paint().apply {
         isFilterBitmap = true

--- a/apex/src/main/java/dev/romainguy/apex/Button.kt
+++ b/apex/src/main/java/dev/romainguy/apex/Button.kt
@@ -10,6 +10,7 @@ enum class State {
     Disabled
 }
 
+// TODO MotionInputComponent generic
 class ButtonModel(
     var label: String,
     var state: State = State.Enabled,
@@ -19,14 +20,14 @@ class ButtonModel(
 }
 
 fun Element.Button(model: ButtonModel) = ChildElement {
-    addComponent(model)
+    addComponent<ButtonModel>(model)
 
     data class InternalState(
         var isPressed: Boolean = false,
         var textWidth: Float = 0.0f,
         var textHeight: Float = 0.0f
     )
-    addComponent(InternalState())
+    addComponent<InternalState>(InternalState())
 
     Padding(RectF(8.0f, 4.0f, 8.0f, 4.0f))
 

--- a/apex/src/main/java/dev/romainguy/apex/Components.kt
+++ b/apex/src/main/java/dev/romainguy/apex/Components.kt
@@ -14,7 +14,7 @@ interface RenderComponent {
 }
 
 fun Element.Render(render: (providers: Providers, element: Element, renderer: Renderer) -> Unit) {
-    addComponent(object : RenderComponent {
+    addComponent<RenderComponent>(object : RenderComponent {
         override fun render(providers: Providers, element: Element, renderer: Renderer) {
             render(providers, element, renderer)
         }
@@ -31,7 +31,7 @@ abstract class LayoutComponent {
 }
 
 fun Element.Layout(layout: (providers: Providers, element: Element, size: SizeF) -> SizeF) {
-    addComponent(object : LayoutComponent() {
+    addComponent<LayoutComponent>(object : LayoutComponent() {
         override fun layout(providers: Providers, element: Element, size: SizeF): SizeF {
             return layout(providers, element, size)
         }
@@ -45,7 +45,7 @@ interface MotionInputComponent {
 fun Element.MotionInput(
     action: (providers: Providers, element: Element, event: MotionEvent) -> Boolean
 ) {
-    addComponent(object : MotionInputComponent {
+    addComponent<MotionInputComponent>(object : MotionInputComponent {
         override fun motionInput(providers: Providers, element: Element, event: MotionEvent): Boolean {
             return action(providers, element, event)
         }
@@ -57,7 +57,7 @@ interface ProviderComponent {
 }
 
 inline fun <reified T : Any> Element.Provider(localProvider: T) {
-    addComponent(object : ProviderComponent {
+    addComponent<ProviderComponent>(object : ProviderComponent {
         override fun provide(providers: Providers, element: Element) {
             providers.set(localProvider)
         }
@@ -69,11 +69,11 @@ class PaddingComponent(val padding: RectF) {
 }
 
 inline fun Element.Padding(padding: RectF) {
-    addComponent(PaddingComponent(padding))
+    addComponent<PaddingComponent>(PaddingComponent(padding))
 }
 
 inline fun Element.Padding(padding: Float) {
-    addComponent(PaddingComponent(padding))
+    addComponent<PaddingComponent>(PaddingComponent(padding))
 }
 
 enum class VerticalAlignment {
@@ -89,9 +89,9 @@ enum class HorizontalAlignment {
 }
 
 inline fun Element.Alignment(alignment: VerticalAlignment) {
-    addComponent(alignment)
+    addComponent<VerticalAlignment>(alignment)
 }
 
 inline fun Element.Alignment(alignment: HorizontalAlignment) {
-    addComponent(alignment)
+    addComponent<HorizontalAlignment>(alignment)
 }

--- a/apex/src/main/java/dev/romainguy/apex/Integration.kt
+++ b/apex/src/main/java/dev/romainguy/apex/Integration.kt
@@ -108,6 +108,7 @@ private class RootElement(context: Context) : Element() {
         override fun doFrame(frameTimeNanos: Long) {
             if (surface == null) return
 
+            // TODO Don't relayout/redraw on every v-sync
             val rootProviders = providers.copyOf()
             applyComponent<ProviderComponent> {
                 provide(rootProviders, this@RootElement)

--- a/apex/src/main/java/dev/romainguy/apex/Providers.kt
+++ b/apex/src/main/java/dev/romainguy/apex/Providers.kt
@@ -12,6 +12,7 @@ import kotlin.collections.set
 import kotlin.math.floor
 import kotlin.reflect.KClass
 
+// TODO Optimize providers handling
 class Providers {
     private val providers: MutableMap<KClass<*>, Any> = mutableMapOf()
 


### PR DESCRIPTION
> Optimize components lookup. Right now, every lookup iterates over a flat list. It's not a big deal since most elements will have a short list but this could be improved. Since it's intended that an element can own multiple components of the same type, you'd probably have a data structure that maps component types to a list (a linked hashmap for instance)

Change MutableList to LinkedHashMap to have the type of the component as a key of this list. Allows to lookup components by type instead of iterate over a flat list when need to lookup of a component.